### PR TITLE
products component

### DIFF
--- a/app/components/Product.js
+++ b/app/components/Product.js
@@ -4,6 +4,7 @@ import React from 'react';
 export default function Product (props) {
 
 
+
   const product = props.selectedProduct;
   console.log('prizz', product)
  
@@ -13,6 +14,7 @@ export default function Product (props) {
       <p>{product.description}</p>
       <p>Price: ${product.price}</p>
       <p>No. Available: {product.inventory}</p>
+      <p>AverageStars: {product.averageStars}</p>
       <div className='row'>
         <img src={product.photoURL}/>
       </div>

--- a/app/components/Products.js
+++ b/app/components/Products.js
@@ -3,20 +3,24 @@ import { Link } from 'react-router';
 
 
 export default function Product (props) {
+  console.log('prezzles',props)
 
-  const allProducts = props.allProducts;
-  const selectOneProduct = props.selectOneProduct;
+
+ let allProducts = props.categoryProducts.length ? props.categoryProducts : props.allProducts;
+
   const addItemToCart = props.addItemToCart;
 
-  const handleClick= (evt, product) => {
+  const handleCartClick= (evt, product) => {
+      //evt.preventDefault()
+      props.addItemToCart(product)
+  }
 
-    if ($(evt.target).hasClass('cart-btn')) {
-      evt.preventDefault()
-      addItemToCart(product)
-    }
-    else {
-      selectOneProduct(product);
-    }
+  const handleProductClick= (evt,product) => {
+      props.selectOneProduct(product)
+  }
+
+  const handleCategoryClick= (evt,product) => {
+      props.selectCategory(product)
   }
 
   return (
@@ -25,26 +29,34 @@ export default function Product (props) {
     {
       allProducts&&allProducts.map(product=>(
 
-        <Link to={'/product'} onClick={e=> handleClick(e, product)} >
-        <div key={product.id} className='well margin10' >
+        
+        <div key={product.id} className='well floatLeft margin10' >
         <li >
-          <button className = 'cart-btn center btn-primary' >Add To Cart!</button>
+          <button className = 'cart-btn center btn-primary' onClick={e=>handleCartClick(e,product)} >Add To Cart</button>
           <h4 className='center'>{product.title}</h4>
           <div className='row'>
           <div className='margin3'>
 
+          <Link to={'/product'} onClick={e=>handleProductClick(e,product)} >
           <img src={product.photoURL}  className='img-thumbnail img-responsive thumbs' />
+          </Link>
           </div>
+           </div>
           <p>Price: ${product.price}</p>
           {
             product.categories.map(category=>(
-              <button key={category.id} className='btn btn-xs btn-primary margin3'>{category.name}</button>
+              <button key={category} className='btn btn-xs btn-primary margin3' onClick={e=>handleCategoryClick(e,category)}>{category}</button>
             ))
           }
-          </div>
+          <p>Average Stars:
+          {
+            (product.reviews.reduce( (a,b)=>a + b.stars,0)/product.reviews.length) || "Not Yet Rated"
+          }
+          </p>
+        
         </li>
         </div>
-        </Link>
+        
 
       ))
     }

--- a/app/components/Review.js
+++ b/app/components/Review.js
@@ -1,0 +1,17 @@
+import React from 'react';
+//import { Link } from 'react-router';
+
+export default function Review (props) {
+
+
+
+  const review = props.selectedProduct.review;
+  console.log('prizz', product)
+ 
+  return (
+    <div>
+      <h3>{review.stars}</h3>
+      <p>{review.content}</p>
+    </div>
+  )
+};

--- a/app/components/Sidebar.jsx
+++ b/app/components/Sidebar.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router';
 const Sidebar = (props) => {
 
   const categories = props.category.categories;
-  console.log('================this is categories', categories)
   return (
     <div>
       <img src="" className="logo" />
@@ -13,7 +12,7 @@ const Sidebar = (props) => {
         <div key={category}>
         <section>
           <h4 className="menu-item active">
-            <Link to='/category' onClick={()=>{props.onClick(category)}}>{category}</Link>
+            <Link to='/products' onClick={()=>{props.onClick(category)}}>{category}</Link>
           </h4>
         </section>
         </div>

--- a/app/containers/CategoryContainer.jsx
+++ b/app/containers/CategoryContainer.jsx
@@ -1,19 +1,26 @@
 import Category from '../components/Category';
 import { connect } from 'react-redux';
 
+import { setOneProduct } from '../reducers/product';
+
 const mapStateToProps = (state) => {
   return {
-    categoryProducts: state.category.selCatProducts
+    categoryProducts: state.category.selCatProducts,
+    selectedProduct: state.product.selectedProduct
   };
 };
 
 const mapDisptachToProps = (dispatch) => {
   return {
-    onClickCat: (category) => {
+    onClickCat (category)  {
       dispatch(loadProductsInCat(category))
+    },   
+    selectOneProduct (product) {
+      dispatch(setOneProduct(product));
     }
   }
 }
+
 const CategoryContainer = connect(mapStateToProps, mapDisptachToProps)(Category);
 
 export default CategoryContainer;

--- a/app/containers/ProductsContainer.js
+++ b/app/containers/ProductsContainer.js
@@ -4,12 +4,14 @@ import { connect } from 'react-redux';
 
 import {addItemToCart} from 'APP/app/reducers/cart'
 import { setOneProduct } from '../reducers/product';
+import {loadProductsInCat} from '../reducers/categories'
 
 
 const mapStateToProps = (state) => {
   return {
     allProducts: state.product.allProducts,
-  	selectedProduct: state.product.selectedProduct
+  	selectedProduct: state.product.selectedProduct,
+    categoryProducts: state.category.selCatProducts
   };
 };
 
@@ -20,7 +22,10 @@ const mapDispatchToProps = (dispatch) => {
     },
     addItemToCart (product) {
       dispatch(addItemToCart(product))
-    }
+    },
+    selectCategory (category) {
+      dispatch(loadProductsInCat(category))
+    },
   }
 }
 

--- a/app/containers/ReviewComponent.js
+++ b/app/containers/ReviewComponent.js
@@ -1,0 +1,13 @@
+
+import Review from '../components/Review';
+import { connect } from 'react-redux';
+
+const mapStateToProps = (state) => {
+  return {
+    selectedProduct: state.product.selectedProduct
+  };
+};
+
+const ReviewContainer = connect(mapStateToProps)(Review);
+
+export default ReviewContainer;

--- a/app/containers/SidebarContainer.jsx
+++ b/app/containers/SidebarContainer.jsx
@@ -2,6 +2,7 @@
 import Sidebar from '../components/Sidebar';
 import { connect } from 'react-redux';
 import {loadProductsInCat} from '../reducers/categories'
+import { setOneProduct } from '../reducers/product';
 
 const mapStateToProps = (state) => {
   return {
@@ -11,11 +12,15 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onClick: (category) => {
+    onClick (category) {
       dispatch(loadProductsInCat(category))
-    }
+    },
+
+    selectOneProduct (product) {
+      dispatch(setOneProduct(product))
+  	}
   }
-}
+ }
 const SidebarContainer = connect(mapStateToProps, mapDispatchToProps)(Sidebar);
 
 export default SidebarContainer;

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -42,7 +42,6 @@ export default function Root () {
           <Route path="/products" component={ProductsContainer} />
           <Route path="/product" component={ProductContainer} />
           <Route path="/cart" component={CartContainer} />
-          <Route path="/category" component={CategoryContainer} />
           <IndexRedirect to="/products"/>
         </Route>
       </Router>

--- a/db/models/product.js
+++ b/db/models/product.js
@@ -2,7 +2,7 @@
 
 const Sequelize = require('sequelize')
 const db = require('APP/db')
-const Category = require('./category')
+const Review = require('./review')
 const Promise = require('bluebird')
 
 const Product = db.define( 'product',  {
@@ -35,6 +35,9 @@ const Product = db.define( 'product',  {
 	}
 
 }, {
+	getterMethods: {
+
+	},
 	instanceMethods: {
 		addInventory: function(numToAdd){
 			this.inventory = this.inventory + numToAdd;

--- a/db/models/review.js
+++ b/db/models/review.js
@@ -6,7 +6,8 @@ const db = require('APP/db')
 const Review = db.define('review', {
 	stars: {
 		type: Sequelize.INTEGER,
-		allowNull: false
+		allowNull: false,
+		validate: {isIn:[[0,1,2,3,4,5]]}
 	},
 	content: {
 		type: Sequelize.TEXT,

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,6 +1,7 @@
 const db = require('APP/db')
 //const Category = require('./models/category');
 const Product = require('./models/product')
+const Review = require('./models/review')
 
 const seedUsers = () => db.Promise.map([
   {name: 'so many', email: 'god@example.com', password: '1234'},
@@ -8,13 +9,26 @@ const seedUsers = () => db.Promise.map([
 ], user => db.model('users').create(user))
 
 const seedProducts = () => db.Promise.map([
-  {title: 'Sos Your Mom', description: 'This is a description', price: 1000, inventory: 5, categories: ['powerboat','pleasurecraft']},  {title: 'Weather Oar Knot', description: 'Here are some workds', price: 4000, inventory: 5, categories: ['powerboat', 'pleasurecraft']},  {title: 'Row vs Wade', description: 'Something to say', price: 0, inventory: 5, categories: ['sailboat', 'pleasurecraft']},  {title: 'Anchors Away', description: 'Something about a thing', price: 200000, inventory: 5, categories: ['powerboat', 'commercial']},  {title: 'BobbleHead', description: 'Splish splash', price: 10000, inventory: 5, categories: ['sailboat','commercial']}], product => Product.create(product))
+  {title: 'Sos Your Mom', description: 'This is a description', price: 1000, inventory: 5, categories: ['powerboat','pleasurecraft']},  {title: 'Weather Oar Knot', description: 'Here are some workds', price: 4000, inventory: 5, categories: ['powerboat', 'pleasurecraft', 'military']},  {title: 'Row vs Wade', description: 'Something to say', price: 0, inventory: 5, categories: ['sailboat', 'pleasurecraft']},  {title: 'Anchors Away', description: 'Something about a thing', price: 200000, inventory: 5, categories: ['powerboat', 'commercial', 'military']},  {title: 'BobbleHead', description: 'Splish splash', price: 10000, inventory: 5, categories: ['sailboat','commercial']}], product => Product.create(product))
+
+const seedReviews = () => db.Promise.map(
+  [  
+    {stars: 4, content: 'i give it a 4!', user_id:1, product_id:1 },
+    {stars: 2, content: 'just a two', user_id:2, product_id:1 },
+    {stars: 4, content: 'pretty damn above average', user_id:2, product_id:2 },
+    {stars: 0, content: 'pretty damn horrible', user_id:2, product_id:3 },
+
+
+  ]
+ , review => Review.create(review))  
 
 db.didSync
   .then(() => db.sync({force: true}))
   .then(seedUsers)
-  .then(users => console.log(`Seeded ${users.length} users OK`))
+  .then(users => console.log(`==================>Seeded ${users.length} users OK`))
   .then(seedProducts)
-  .then(products => console.log('==================>Seeded Products'))
+  .then(products => console.log(`==================>Seeded ${products.length} Products`))
+  .then(seedReviews)
+  .then(reviews => console.log(`==================>Seeded ${reviews.length} Reviews`))
   .catch(error => console.error(error))
   .finally(() => db.close())

--- a/server/products.js
+++ b/server/products.js
@@ -2,18 +2,17 @@
 
 const db = require('APP/db')
 const Product = require('../db/models/product')
-
-
+const User = require('../db/models/user')
 const Review = require('../db/models/review')
 
 module.exports = require('express').Router()
   .get('/', (req, res, next) =>
-    Product.findAll()
+    Product.findAll({include: [ { model: Review, include: [User]}]})
     .then(products => res.json(products))
     .catch(next))
 
   .param('productId', (req, res, next, theProductId) =>
-    Product.findOne({where: {id:theProductId}, include: [Review]})
+    Product.findOne({where: {id:theProductId}, include: [ {model: Review, include: [User]}] })
     .then(product => {
       if (!product) {
         const err = Error('Product Not Found');
@@ -38,7 +37,8 @@ module.exports = require('express').Router()
         categories: {
           $overlap: [req.params.category]
         }
-      }
+      },include: [ {model: Review, include: [User]}]
+
     })
     .then(products => res.json(products))
     .catch(next);


### PR DESCRIPTION
Closes #40 

@galxzx and @AndrewBasore : it wasn't working when you selected a product and then a category and then a product. the props were getting lost in the transition b/n components. I reconfigured it to simply map selectedProducts if they are present, and all products if they are not. The only stipulation is that all categories listed in the sidebar need at least one product associated with them- or else all products will render when that 'empty category' is selected.  

This shouldn't be a problem with proper seeding. Also, when items are sold out, I think they should still be displayed- but disabled.  And they would be at the end of the display list too... maybe with a little 'sold out' sign on them... and they could have more opacity as well. 

I didn't make much progress on the review components b/c I was reconfiguring the products component. Will jam out the review components tomorrow. Please review and merge.